### PR TITLE
PR for Issue #18

### DIFF
--- a/webapp/i18n/i18n.properties
+++ b/webapp/i18n/i18n.properties
@@ -178,8 +178,10 @@ columnEMail=Email
 columnMobilePhone=MobilePhone
 #XTIT: Label RSVP
 columnRSVP=RSVP
-#XTIT: Label Mobile Phone
+#XTIT: Label Participated
 columnParticipated=Participated
+#XTIT: Label Participated
+ParticipantNumbersParticipated=Participated
 
 
 #~~~ Not Found View ~~~~~~~~~~~~~~~~~~~~~~~

--- a/webapp/i18n/i18n.properties
+++ b/webapp/i18n/i18n.properties
@@ -178,13 +178,13 @@ leavePage=Leave Page
 #XTIT: Title of confirmation dialog
 delete=Delete
 #XTIT: Label First Name
-columnFirstName=FirstName
+columnFirstName=First Name
 #XTIT: Label Last Name
-columnLastName=LastName
+columnLastName=Last Name
 #XTIT: Label Email
 columnEMail=Email
 #XTIT: Label Mobile Phone
-columnMobilePhone=MobilePhone
+columnMobilePhone=Mobile Phone
 #XTIT: Label RSVP
 columnRSVP=RSVP
 #XTIT: Label Participated

--- a/webapp/view/EventForm.fragment.xml
+++ b/webapp/view/EventForm.fragment.xml
@@ -32,6 +32,8 @@
 			<Text text="{RegistrationNumbers/Free}"/>
 			<Label text="{i18n>RegistrationNumbersParticipants}"/>
 			<Text text="{RegistrationNumbers/Participants}"/>
+			<Label text="{i18n>ParticipantNumbersParticipated}"/>
+			<Text text="{ParticipantNumbers/Participated}"/>
 			<Label text="{i18n>PreEveningEvent}"/>
 			<Text text="{PrePostEveningEventNumbers/PreEveningEvent}"/>
 			<Label text="{i18n>PostEveningEvent}"/>

--- a/webapp/view/Master.view.xml
+++ b/webapp/view/Master.view.xml
@@ -18,7 +18,7 @@
 					path: '/Events', 
 					sorter: { path: 'Location', descending: false }, 
 					parameters:{
-						expand:'EventChangeable,RegistrationNumbers,PrePostEveningEventNumbers'
+						expand:'EventChangeable,RegistrationNumbers,PrePostEveningEventNumbers,ParticipantNumbers'
 					},
 					groupHeaderFactory: '.createGroupHeader' 
 				}"

--- a/webapp/view/PartipicantsTable.fragment.xml
+++ b/webapp/view/PartipicantsTable.fragment.xml
@@ -42,7 +42,7 @@
 			</Column>
 		</columns>
 		<items>
-			<ColumnListItem type="Navigation" press="onPress">
+			<ColumnListItem type="Inactive" press="onPress">
 				<cells>
 					<ObjectIdentifier title="{ID}"/>
 					<Text text="{FirstName}"/>


### PR DESCRIPTION
I have made the participant line item in the table inactive, so the arrow/chevron is no longer visible. This can be reimplemented if/when that functionality is available. I also fixed the texts FirstName, LastName and MobilePhone to in i18n to include spaces in the column headers.

![image](https://cloud.githubusercontent.com/assets/6735410/19500187/ab215fe2-95e6-11e6-9960-f0862112fe7a.png)

It seems to be pulling in my commits from yesterday too (fixes to the devices tab texts and the change of the tab icon to phone), not really sure why.